### PR TITLE
Variável MICRO_DRIVERS_URL alterada para endereço interno http://driv…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
-MICRO_DRIVERS_URL=http://192.168.56.1:8081
+MICRO_DRIVERS_URL=http://drivers-app:8081
 MICRO_MAPPING_URL=http://localhost:3002


### PR DESCRIPTION
Variável MICRO_DRIVERS_URL alterada para endereço interno http://drivers-app:8081 para facilitar o apontamento.

Creio que facilita para não ter que "descobrir" o ip do docker. 

No microserviço de drivers, foi criado um docker-compose e a network do orders foi adicionada nele.